### PR TITLE
Update fluentd version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.9.2-1.0
+FROM fluent/fluentd:v1.14-1
 ENV LOG_LEVEL="warn"
 ENV BASE_URI="https://log-api.newrelic.com/log/v1"
 


### PR DESCRIPTION
Version 1.9 is now 2 years old. Updating the container to 1.14 worked
without problems in my local tests.