### PR TITLE
fix(fluentd): remove insert key

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ The command below configures the container to receive and forward log events fro
 
 ```bash 
 docker run --name="newrelic-fluentd-docker" --restart=always -d -p 24224:24224 \
--e "API_KEY=<YOUR API INSERT KEY>" -e "BASE_URI=<YOUR HTTP ENDPOINT>" \ 
+-e "API_KEY=<YOUR LICENSE KEY>" -e "BASE_URI=<YOUR HTTP ENDPOINT>" \ 
 -e "LOG_LEVEL=<YOUR DEFAULT LOG LEVEL>" newrelic/newrelic-fluentd-docker:latest
 ```
 ### Custom Fluentd Configuration
@@ -28,15 +28,9 @@ docker build . -t newrelic-fluentd-docker
 
 ###  Environment Variables
 
-
 | Property | Description | Default Value | Required or Optional
 |---|---|---|---|
-| API_KEY | Your New Relic API [insert key](https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api#register)|-|Required 
+| API_KEY | Your New Relic [license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key)|-|Required 
 | BASE_URI | New Relic [ingestion endpoint](https://docs.newrelic.com/docs/logs/new-relic-logs/log-api/introduction-log-api#endpoint)|`https://log-api.newrelic.com/log/v1`|Optional
 | LOG_LEVEL | Fluentd [log level](https://docs.fluentd.org/deployment/logging#log-level)|`warn`|Optional
-
-### Getting Your Keys
-
-* You can retrieve your New Relic Insights [insert key](https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api#register) from the following location:
-`https://insights.newrelic.com/accounts/<YOUR ACCOUNT ID>/manage/api_keys`
 


### PR DESCRIPTION
I'm on docs team. Attempting to remove mentions of 'Insights insert key' as that has been mostly deprecated in favor of recommending the license key (they're interchangeable but want to align on license key). 